### PR TITLE
Fix an issue that notification won’t be shown when using osascript on macOS 10.13

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -146,7 +146,7 @@ func CheckMacOSVersion() bool {
 	cmd := exec.Command("sw_vers", "-productVersion")
 	check, _ := cmd.Output()
 
-	version := strings.Split(string(check), ".")
+	version := strings.Split(strings.TrimSpace(string(check)), ".")
 
 	// semantic versioning of macOS
 


### PR DESCRIPTION
`sw_vers -productVersion` returns version string with trailing line break.

It's OK if you using macOS 10.12.6 because this package needs 2nd elements of slice.
However there is pitfall when you are using High Sierra because version string is `10.13\n` and strconv.Atoi() can't convert `13\n` to `13`

So I added a trimming.

Thank you.
