### PR TITLE
Add AppName support for notify-send

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -84,15 +84,17 @@ func (o osxNotificator) pushCritical(title string, text string, iconPath string)
 
 }
 
-type linuxNotificator struct{}
+type linuxNotificator struct {
+	AppName string
+}
 
 func (l linuxNotificator) push(title string, text string, iconPath string) *exec.Cmd {
-	return exec.Command("notify-send", "-i", iconPath, title, text)
+	return exec.Command("notify-send", "-i", iconPath, title, text, "-a", l.AppName)
 }
 
 // Causes the notification to stick around until clicked.
 func (l linuxNotificator) pushCritical(title string, text string, iconPath string) *exec.Cmd {
-	return exec.Command("notify-send", "-i", iconPath, title, text, "-u", "critical")
+	return exec.Command("notify-send", "-i", iconPath, title, text, "-a", l.AppName, "-u", "critical")
 }
 
 type windowsNotificator struct{}
@@ -115,7 +117,7 @@ func New(o Options) *Notificator {
 	case "darwin":
 		Notifier = osxNotificator{AppName: o.AppName}
 	case "linux":
-		Notifier = linuxNotificator{}
+		Notifier = linuxNotificator{AppName: o.AppName}
 	case "windows":
 		Notifier = windowsNotificator{}
 


### PR DESCRIPTION
Previously, only the OSX notifier could use the AppName property. This adds support for it on Linux via notify-send.