### PR TITLE
add go mod

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"../../notificator"
 	"log"
+
+	"github.com/0xAX/notificator"
 )
 
 var notify *notificator.Notificator

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/0xAX/notificator
+
+go 1.16


### PR DESCRIPTION
```console
go version                                                                                                                                                                                                                                                                                    
go version go1.16.6 darwin/arm64
 
go run example/main.go                                                                                                                                                                                                                                                                        
build command-line-arguments: cannot find module for path _/Users/sivchari/workspace/notificator
```

Since Go1.11, we cannot use relative path.
So, this example is not working. 

I added go.mod and fixed example.